### PR TITLE
Added route to destroy favorite if api_key present

### DIFF
--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -98,5 +98,23 @@ router.post('/', function(req, res, next) {
   }
 });
 
+router.delete('/', function(req, res, next) {
+  if (req.body.hasOwnProperty('api_key')){
+    FavoriteCities.destroy({
+      where: {
+        location: req.body.location
+      }
+    }).then(favCity => {
+      res.setHeader('Content-Type', 'application/sjon');
+      res.status(204)
+    }).catch(error => {
+      res.setHeader("Content-Type", "application/json");
+      res.status(500).send({ error });
+    });
+  } else {
+    res.setHeader("Content-Type", "application/json");
+    res.status(401).send(JSON.stringify({message: 'Unauthorized User'}));
+  }
+})
 
 module.exports = router;


### PR DESCRIPTION
- [] Wrote Tests
- [x] Implemented
- [] Reviewed

# Necessary checkmarks:
- [] All Tests are Passing
- [x] The code will run locally

## Type of change
- [x] New feature
- [] Bug Fix

# Implements/Fixes:
### Deleting a favorite city and returning a 204 status
![image](https://user-images.githubusercontent.com/45864171/60438713-95c82180-9bce-11e9-9320-6d0d1cd06210.png)

###  If no api_key present will return 401 error
![image](https://user-images.githubusercontent.com/45864171/60438836-d6279f80-9bce-11e9-9af6-3d8c649dd385.png)

## Description of Changes:

closes #7 

# Check the correct boxes
- [x] This broke nothing
- [] This broke some stuff
- [] This broke everything

# Testing Changes
- [] No Tests have been changed
- [] Some Tests have been changed
- [] All of the Tests have been changed (Please describe what in the world happened)

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have fully tested my code
